### PR TITLE
Manually export to global.lily and global.connect.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,8 +20,7 @@ module.exports = function (grunt) {
                 dest: './out/connect-rtc-debug.js',
                 options: {
                     browserifyOptions: {
-                        debug: true,
-                        standalone: 'connect'
+                        debug: true
                     },
                     transform: [["babelify", { "presets": ["env"] }]],
                 }
@@ -32,9 +31,6 @@ module.exports = function (grunt) {
                 ],
                 dest: './out/connect-rtc.js',
                 options: {
-                    browserifyOptions: {
-                        standalone: 'connect'
-                    },
                     transform: [["babelify", { "presets": ["env"] }]],
                 }
             }

--- a/src/js/connect-rtc.js
+++ b/src/js/connect-rtc.js
@@ -48,6 +48,10 @@ import 'webrtc-adapter';
 import RtcSession from './rtc_session';
 import {RTC_ERRORS} from './rtc_const';
 
-export const RTCSession = RtcSession;
-export const RTCErrors = RTC_ERRORS;
+global.connect = global.connect || {};
+global.connect.RTCSession = RtcSession;
+global.connect.RTCErrors = RTC_ERRORS;
 
+global.lily = global.lily || {};
+global.lily.RTCSession = RtcSession;
+global.lily.RTCErrors = RTC_ERRORS;


### PR DESCRIPTION
Browserify standalone bundle overrides existing global object rather than merging.