### PR TITLE
Making contextToken optional parameter on the Session constructor

### DIFF
--- a/src/js/rtc_session.js
+++ b/src/js/rtc_session.js
@@ -425,7 +425,7 @@ export default class RtcSession {
      * Build an AmazonConnect RTC session.
      * @param {*} signalingUri
      * @param {*} iceServers Array of ice servers
-     * @param {*} contactToken
+     * @param {*} contactToken A string representing the contact token (optional)
      * @param {*} logger An object provides logging functions, such as console
      * @param {*} contactId Must be UUID, uniquely identifies the session.
      */
@@ -437,7 +437,9 @@ export default class RtcSession {
             throw new IllegalParameters('iceServers required');
         }
         if (typeof contactToken !== 'string' || contactToken.trim().length === 0) {
-            throw new IllegalParameters('contactToken required');
+            this._contactToken = null;
+        } else {
+            this._contactToken = contactToken;
         }
         if (typeof logger !== 'object') {
             throw new IllegalParameters('logger required');
@@ -451,7 +453,6 @@ export default class RtcSession {
         this._sessionReport = new SessionReport();
         this._signalingUri = signalingUri;
         this._iceServers = iceServers;
-        this._contactToken = contactToken;
         this._originalLogger = logger;
         this._logger = wrapLogger(this._originalLogger, this._callId, 'SESSION');
         this._iceTimeoutMillis = DEFAULT_ICE_TIMEOUT_MS;

--- a/src/js/rtc_session.js
+++ b/src/js/rtc_session.js
@@ -436,11 +436,6 @@ export default class RtcSession {
         if (!iceServers) {
             throw new IllegalParameters('iceServers required');
         }
-        if (typeof contactToken !== 'string' || contactToken.trim().length === 0) {
-            this._contactToken = null;
-        } else {
-            this._contactToken = contactToken;
-        }
         if (typeof logger !== 'object') {
             throw new IllegalParameters('logger required');
         }
@@ -453,6 +448,7 @@ export default class RtcSession {
         this._sessionReport = new SessionReport();
         this._signalingUri = signalingUri;
         this._iceServers = iceServers;
+        this._contactToken = contactToken;
         this._originalLogger = logger;
         this._logger = wrapLogger(this._originalLogger, this._callId, 'SESSION');
         this._iceTimeoutMillis = DEFAULT_ICE_TIMEOUT_MS;

--- a/src/js/signaling.js
+++ b/src/js/signaling.js
@@ -418,13 +418,21 @@ export default class AmznRtcSignaling {
         return wsConnection;
     }
     _buildInviteUri() {
-        return this._buildUriBase() + '&contactCtx=' + encodeURIComponent(this._contactToken);
+        if (this._contactToken) {
+            return this._buildUriBase() + '&contactCtx=' + encodeURIComponent(this._contactToken);
+        } else {
+            return this._buildUriBase();
+        }
     }
     _buildReconnectUri() {
         return this._buildUriBase() + '&clientToken=' + encodeURIComponent(this._clientToken);
     }
     _buildUriBase() {
-        return this._signalingUri + '?callId=' + encodeURIComponent(this._callId);
+        var separator = '?';
+        if (this._signalingUri.indexOf(separator) > -1) {
+            separator = '&';
+        }
+        return this._signalingUri + separator + 'callId=' + encodeURIComponent(this._callId);
     }
     _onMessage(evt) {
         this.state.onRpcMsg(JSON.parse(evt.data));


### PR DESCRIPTION
This change is making the contextToken optional so it can be passed as part of the signaling URI