### PR TITLE
Allowing user to set Video and Audio Codec in the page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -25,6 +25,22 @@
     <label for="enable-video">Enable Video</label>
     </div>
     <div>
+        <label>Set Audio Codec</label>
+        <select id="forced-audio-codec">
+            <option value="NONE">None</option>
+            <option value="OPUS">OPUS</option>
+        </select>
+    </div>
+    <div>
+        <label>Set Video Codec</label>
+        <select id="forced-video-codec">
+            <option value="NONE">None</option>
+            <option value="VP8">VP8</option>
+            <option value="VP9">VP9</option>
+            <option value="H264">H.264</option>
+        </select>
+    </div>
+    <div>
         <button id='makeCall'>Call</button>
         <button id='disconnectCall' disabled="true">Hangup</button>
     </div>

--- a/demo/index.js
+++ b/demo/index.js
@@ -20,6 +20,12 @@ $(document).ready(function () {
 
         session.forceAudioCodec = 'OPUS';
 
+        // Set video codec if it presents
+        var forceVideoCodec = $('#forced-video-codec option:selected').val();
+        if (forceVideoCodec !== 'NONE') {
+            session.forceVideoCodec = forceVideoCodec;
+        }
+
         if ($('#enable-video')[0].checked) {
           $('#video-display')[0].style.display = 'block';
           session.remoteVideoElement = videoElement;

--- a/src/js/rtc_session.js
+++ b/src/js/rtc_session.js
@@ -138,8 +138,13 @@ export class SetLocalSessionDescriptionState extends RTCSessionState {
         // fix/modify SDP as needed here, before setLocalDescription
         var localDescription = self._rtcSession._localSessionDescription;
         var sdpOptions = new SdpOptions();
+        // Set audio codec.
         if (self._rtcSession._forceAudioCodec) {
             sdpOptions.forceCodec['audio'] = self._rtcSession._forceAudioCodec;
+        }
+        // Set video codec.
+        if (self._rtcSession._forceVideoCodec) {
+            sdpOptions.forceCodec['video'] = self._rtcSession._forceVideoCodec;
         }
         sdpOptions.enableOpusDtx = self._rtcSession._enableOpusDtx;
 
@@ -771,10 +776,20 @@ export default class RtcSession {
      * connect-rtc-js initiate the handshaking with all browser supported codec by default, Amazon Connect service will choose the codec according to its preference setting.
      * Setting this attribute will force connect-rtc-js to only use specified codec.
      * WARNING: Setting this to unsupported codec will cause the failure of handshaking.
-     * Supported codecs: opus.
+     * Supported audio codecs: opus.
      */
     set forceAudioCodec(audioCodec) {
         this._forceAudioCodec = audioCodec;
+    }
+
+    /**
+     * connect-rtc-js initiate the handshaking with all browser supported codec by default, Amazon Connect service will choose the codec according to its preference setting.
+     * Setting this attribute will force connect-rtc-js to only use specified codec.
+     * WARNING: Setting this to unsupported codec will cause the failure of handshaking.
+     * Supported video codecs: VP8, VP9, H264.
+     */
+    set forceVideoCodec(videoCodec) {
+        this._forceVideoCodec = videoCodec;
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*
Allow the user to manually set audio or video codec from the demo page.

*Description of changes:*
- Adding two new dropdown lists in the index page: setting audio codec; setting video codec.
- If None is selected, then do not set any audio / video codec
- If an audio codec is selected, do nothing, and set audio codec to opus (to conform with current business logic)
- If a video codec is selected, then set video codec to the one which is selected.
- Note that: H264 is not supported for now.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
