### PR TITLE
added optional support for echoCancellationType

### DIFF
--- a/src/js/rtc_session.js
+++ b/src/js/rtc_session.js
@@ -703,6 +703,9 @@ export default class RtcSession {
     set echoCancellation(flag) {
         this._echoCancellation = flag;
     }
+    set echoCancellationType(type) {
+        this._echoCancellationType = type;
+    }
     set enableVideo(flag) {
         this._enableVideo = flag;
     }
@@ -1087,6 +1090,9 @@ export default class RtcSession {
             var audioConstraints = {};
             if (typeof self._echoCancellation !== 'undefined') {
                 audioConstraints.echoCancellation = !!self._echoCancellation;
+            }
+            if (typeof self._echoCancellationType !== 'undefined') {
+                audioConstraints.echoCancellationType = self._echoCancellationType;
             }
             if (Object.keys(audioConstraints).length > 0) {
                 mediaConstraints.audio = audioConstraints;


### PR DESCRIPTION
*Issue #, if available:*
Currently there is not a way to add support for echoCancellationType. https://developers.google.com/web/updates/2018/06/more-native-echo-cancellation

*Description of changes:*
Added optional setter for echoCancellationType

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
