### PR TITLE
fix: replace userAudioStream with localStream in GrabLocalMediaState

### DIFF
--- a/src/js/rtc_session.js
+++ b/src/js/rtc_session.js
@@ -68,7 +68,7 @@ export class GrabLocalMediaState extends RTCSessionState {
     onEnter() {
         var self = this;
         var startTime = Date.now();
-        if (self._rtcSession._userAudioStream) {
+        if (self._rtcSession._localStream) {
             self.transit(new CreateOfferState(self._rtcSession));
         } else {
             var gumTimeoutPromise = new Promise((resolve, reject) => {


### PR DESCRIPTION
*Issue #, if available:*
Currently ```_userAudioStream``` is not being used and it appears this conditional is a mistake.

*Description of changes:*
Changed conditional to check ```_localStream``` instead.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
