### PR TITLE
feat: added support for raw stats from RTCPeerConnection

### DIFF
--- a/src/js/rtc_session.js
+++ b/src/js/rtc_session.js
@@ -964,6 +964,16 @@ export default class RtcSession {
         }
 
     }
+    /**
+     * Get a promise containing raw object all RTCPeerConnection stats.
+     * @return Rejected promise if failed to get MediaRtpStats. The promise is never resolved with null value.
+     */
+    async getStatsRaw() {
+        if (this._pc && this._pc.signalingState === 'stable') {
+            return await this._pc.getStats(null);
+        }
+        return Promise.reject(new IllegalState());
+    }
 
     /**
      * Get a promise of MediaRtpStats object for remote audio (from Amazon Connect to client).


### PR DESCRIPTION
*Issue #, if available:*
Currently the ```getStats()``` returns data that is translated and highly structured. This does not give client's much flexibility when compiling stats from the call.

*Description of changes:*
Added ```getStatsRaw()``` to enable clients to digest the raw stats from RTCPeerConnection object rather than the media tracks themselves. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
