### PR TITLE
add plan-b' as sdpSemantics to overwrite chrom default sdp version

### DIFF
--- a/src/js/rtc_session.js
+++ b/src/js/rtc_session.js
@@ -864,7 +864,8 @@ export default class RtcSession {
             iceServers: self._iceServers,
             iceTransportPolicy: 'relay',
             rtcpMuxPolicy: 'require',
-            bundlePolicy: 'balanced'
+            bundlePolicy: 'balanced',
+            sdpSemantics: 'plan-b'
         }, {
             optional: [
                 {


### PR DESCRIPTION
*Issue #, https://github.com/aws/connect-rtc-js/issues/33

*Description of changes:*
This change will overwrite the default unified sdp semantic for chrome new version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
