### PR TITLE
handle empty ice candidate generated by Firefox 69.0b3

### DIFF
--- a/src/js/rtc_session.js
+++ b/src/js/rtc_session.js
@@ -218,10 +218,11 @@ export class ConnectSignalingAndIceCollectionState extends RTCSessionState {
         var candidate = evt.candidate;
         this.logger.log('onicecandidate ' + JSON.stringify(candidate));
         if (candidate) {
-            this._iceCandidates.push(this._createLocalCandidate(candidate));
-
-            if (!this._iceCompleted) {
-                this._checkCandidatesSufficient(candidate);
+            if (candidate.candidate) {
+                this._iceCandidates.push(this._createLocalCandidate(candidate));
+                if (!this._iceCompleted) {
+                    this._checkCandidatesSufficient(candidate);
+                }
             }
 
         } else {


### PR DESCRIPTION
*Issue #, if available:*
Firefox in its 69.0b3 generates empty ice candidate like
onicecandidate {"candidate":"","sdpMid":"0","sdpMLineIndex":0,"usernameFragment":"abcd"}
These type of candidate generates line like a= in sdp. Lines like a= in sdp causes signaling handshake to fail

*Description of changes:*
We will check candidate is not empty before adding it into the ice collected list

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
