### PR TITLE
update getStats API for Firefox 69.0b3

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "test": "grunt && mocha --compilers js:babel-core/register test/unit"
   },
   "dependencies": {
-    "webrtc-adapter": "~2.0.5",
-    "uuid": "^3.0.1"
+    "uuid": "^3.0.1",
+    "webrtc-adapter": "^6.4.0"
   },
   "engines": {
     "npm": ">=3.10.0",

--- a/src/js/rtc_session.js
+++ b/src/js/rtc_session.js
@@ -7,7 +7,7 @@
  *
  * or in the "LICENSE" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, express or implied. See the License for the specific language governing permissions and limitations under the License.
  */
-import { hitch, wrapLogger, closeStream, SdpOptions, transformSdp } from './utils';
+import { hitch, wrapLogger, closeStream, SdpOptions, transformSdp, isLegacyStatsReportSupported } from './utils';
 import { SessionReport } from './session_report';
 import { DEFAULT_ICE_TIMEOUT_MS, DEFAULT_GUM_TIMEOUT_MS, RTC_ERRORS } from './rtc_const';
 import { UnsupportedOperation, IllegalParameters, IllegalState, GumTimeout, BusyExceptionName, CallNotFoundExceptionName } from './exceptions';
@@ -880,30 +880,16 @@ export default class RtcSession {
         self._pc.onicecandidate = hitch(self, self._onIceCandidate);
         self._pc.oniceconnectionstatechange = hitch(self, self._onIceStateChange);
 
-        self._isLegacyStatsReportSupported(function(result) {
+        isLegacyStatsReportSupported(self._pc).then(result => {
             self._legacyStatsReportSupport = result;
+            self.transit(new GrabLocalMediaState(self));
         });
-        self.transit(new GrabLocalMediaState(self));
     }
     accept() {
         throw new UnsupportedOperation('accept does not go through signaling channel at this moment');
     }
     hangup() {
         this._state.hangup();
-    }
-
-    /**
-     * Check if the getStats API for retrieving legacy stats report is supported
-     */
-    _isLegacyStatsReportSupported(callback) {
-        this._pc.getStats(function() {
-            callback(true);
-        }).catch(function(e) {
-            // TypeError if browser does not support legacy stats report
-            if (e instanceof TypeError) {
-                callback(false);
-            }
-        });
     }
 
     /**

--- a/src/js/rtp-stats.js
+++ b/src/js/rtp-stats.js
@@ -22,7 +22,7 @@ export function extractMediaStatsFromStats(timestamp, stats, streamType) {
                         bytesSent:          parseInt(statsReport.stat('bytesSent')),
                         audioLevel:         when_defined(parseInt(statsReport.stat('audioInputLevel'))),
                         packetsLost:        is_defined(statsReport.stat('packetsLost')) ? Math.max(0, statsReport.stat('packetsLost')) : 0,
-                        procMilliseconds:   is_defined(parseInt(statsReport.stat('googCurrentDelayMs'))),
+                        procMilliseconds:   when_defined(parseInt(statsReport.stat('googCurrentDelayMs'))),
                         rttMilliseconds:    when_defined(parseInt(statsReport.stat('googRtt'))),
                         jbMilliseconds:     when_defined(parseInt(statsReport.stat('googJitterReceived')))
                     };
@@ -34,7 +34,7 @@ export function extractMediaStatsFromStats(timestamp, stats, streamType) {
                         bytesReceived:      parseInt(statsReport.stat('bytesReceived')),
                         audioLevel:         when_defined(parseInt(statsReport.stat('audioOutputLevel'))),
                         packetsLost:        is_defined(parseInt(statsReport.stat('packetsLost'))) ? Math.max(0, statsReport.stat('packetsLost')) : 0,
-                        procMilliseconds:   is_defined(parseInt(statsReport.stat('googCurrentDelayMs'))),
+                        procMilliseconds:   when_defined(parseInt(statsReport.stat('googCurrentDelayMs'))),
                         jbMilliseconds:     when_defined(parseInt(statsReport.stat('googJitterReceived')))
                     };
 
@@ -45,7 +45,7 @@ export function extractMediaStatsFromStats(timestamp, stats, streamType) {
                         bytesSent:          parseInt(statsReport.stat('bytesSent')),
                         packetsLost:        is_defined(statsReport.stat('packetsLost')) ? Math.max(0, statsReport.stat('packetsLost')) : 0,
                         rttMilliseconds:    when_defined(parseInt(statsReport.stat('googRtt'))),
-                        procMilliseconds:   is_defined(parseInt(statsReport.stat('googCurrentDelayMs'))),
+                        procMilliseconds:   when_defined(parseInt(statsReport.stat('googCurrentDelayMs'))),
                         frameRateSent:      when_defined(parseFloat(statsReport.stat('googFrameRateSent')))
                     };
 
@@ -56,7 +56,7 @@ export function extractMediaStatsFromStats(timestamp, stats, streamType) {
                         bytesReceived:      parseInt(statsReport.stat('bytesReceived')),
                         packetsLost:        is_defined(parseInt(statsReport.stat('packetsLost'))) ? Math.max(0, statsReport.stat('packetsLost')) : 0,
                         frameRateReceived:  when_defined(parseFloat(statsReport.stat('statsReport.googFrameRateReceived'))),
-                        procMilliseconds:   is_defined(parseInt(statsReport.stat('googCurrentDelayMs'))),
+                        procMilliseconds:   when_defined(parseInt(statsReport.stat('googCurrentDelayMs'))),
                         jbMilliseconds:     when_defined(parseInt(statsReport.stat('googJitterReceived')))
                     };
 
@@ -116,6 +116,7 @@ class MediaRtpStats {
         this._packetsLost       = when_defined(params.packetsLost);
         this._packetsCount      = when_defined(params.packetsCount);
         this._audioLevel        = when_defined(params.audioLevel);
+        this._procMilliseconds  = when_defined(params.procMilliseconds);
         this._rttMilliseconds   = when_defined(params.rttMilliseconds);
         this._jbMilliseconds    = when_defined(params.jbMilliseconds);
         this._bytesSent         = when_defined(params.bytesSent);
@@ -150,11 +151,15 @@ class MediaRtpStats {
     get timestamp() {
         return this._timestamp;
     }
+    /** {number} Processing delay calculated by time to process packet header */
+    get procMilliseconds() {
+        return this._procMilliseconds
+    }
     /** {number} Round trip time calculated with RTCP reports */
     get rttMilliseconds() {
         return this._rttMilliseconds;
     }
-    /** {number} Browser/client side jitter buffer length */
+    /** {number} Statistical variance of RTP data packet inter-arrival time */
     get jbMilliseconds() {
         return this._jbMilliseconds;
     }

--- a/src/js/rtp-stats.js
+++ b/src/js/rtp-stats.js
@@ -21,7 +21,7 @@ export function extractMediaStatsFromStats(timestamp, stats, streamType) {
                         packetsCount:       parseInt(statsReport.stat('packetsSent')),
                         bytesSent:          parseInt(statsReport.stat('bytesSent')),
                         audioLevel:         when_defined(parseInt(statsReport.stat('audioInputLevel'))),
-                        packetsLost:        is_defined(statsReport.stat('packetsLost')) ? Math.max(0, parseInt(statsReport.stat('packetsLost'))) : 0,
+                        packetsLost:        is_defined(statsReport.stat('packetsLost')) ? Math.max(0, statsReport.stat('packetsLost')) : 0,
                         procMilliseconds:   is_defined(parseInt(statsReport.stat('googCurrentDelayMs'))),
                         rttMilliseconds:    when_defined(parseInt(statsReport.stat('googRtt'))),
                         jbMilliseconds:     when_defined(parseInt(statsReport.stat('googJitterReceived')))
@@ -33,7 +33,7 @@ export function extractMediaStatsFromStats(timestamp, stats, streamType) {
                         packetsCount:       parseInt(statsReport.stat('packetsReceived')),
                         bytesReceived:      parseInt(statsReport.stat('bytesReceived')),
                         audioLevel:         when_defined(parseInt(statsReport.stat('audioOutputLevel'))),
-                        packetsLost:        is_defined(parseInt(statsReport.stat('packetsLost'))) ? Math.max(0, parseInt(statsReport.stat('packetsLost'))) : 0,
+                        packetsLost:        is_defined(parseInt(statsReport.stat('packetsLost'))) ? Math.max(0, statsReport.stat('packetsLost')) : 0,
                         procMilliseconds:   is_defined(parseInt(statsReport.stat('googCurrentDelayMs'))),
                         jbMilliseconds:     when_defined(parseInt(statsReport.stat('googJitterReceived')))
                     };
@@ -44,7 +44,7 @@ export function extractMediaStatsFromStats(timestamp, stats, streamType) {
                         packetsCount:       parseInt(statsReport.stat('packetsSent')),
                         bytesSent:          parseInt(statsReport.stat('bytesSent')),
                         audioLevel:         when_defined(parseInt(statsReport.stat('audioInputLevel'))),
-                        packetsLost:        is_defined(statsReport.stat('packetsLost')) ? Math.max(0, parseInt(statsReport.stat('packetsLost'))) : 0,
+                        packetsLost:        is_defined(statsReport.stat('packetsLost')) ? Math.max(0, statsReport.stat('packetsLost')) : 0,
                         procMilliseconds:   is_defined(parseInt(statsReport.stat('googCurrentDelayMs'))),
                         frameRateSent:      when_defined(parseFloat(statsReport.stat('googFrameRateSent')))
                     };
@@ -54,7 +54,7 @@ export function extractMediaStatsFromStats(timestamp, stats, streamType) {
                         timestamp:          timestamp,
                         packetsCount:       parseInt(statsReport.stat('packetsSent')),
                         bytesReceived:      parseInt(statsReport.stat('bytesReceived')),
-                        packetsLost:        is_defined(parseInt(statsReport.stat('packetsLost'))) ? Math.max(0, parseInt(statsReport.stat('packetsLost'))) : 0,
+                        packetsLost:        is_defined(parseInt(statsReport.stat('packetsLost'))) ? Math.max(0, statsReport.stat('packetsLost')) : 0,
                         frameRateReceived:  when_defined(parseFloat(stat('statsReport.googFrameRateReceived'))),
                         procMilliseconds:   is_defined(parseInt(statsReport.stat('googCurrentDelayMs'))),
                         jbMilliseconds:     when_defined(parseInt(statsReport.stat('googJitterReceived')))

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -216,11 +216,9 @@ export function isLegacyStatsReportSupported(pc) {
     return new Promise(function(resolve) {
         pc.getStats(function() {
             resolve(true);
-        }).catch(function(e) {
-            // TypeError if browser does not support legacy stats report
-            if (e instanceof TypeError) {
-                resolve(false);
-            }
+        }).catch(function() {
+            // Exception thrown if browser does not support legacy stats report
+            resolve(false);
         });
     });
 }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -209,3 +209,19 @@ export function when_defined(v, alternativeIn) {
     return is_defined(v) ? v : alternative;
 }
 
+/**
+ * Check if the getStats API for retrieving legacy stats report is supported
+ */
+export function isLegacyStatsReportSupported(pc) {
+    return new Promise(function(resolve) {
+        pc.getStats(function() {
+            resolve(true);
+        }).catch(function(e) {
+            // TypeError if browser does not support legacy stats report
+            if (e instanceof TypeError) {
+                resolve(false);
+            }
+        });
+    });
+}
+


### PR DESCRIPTION
*Issue #, if available:*
Issue #46: getStats API returned empty for Firefox 69.0b3 because of outdated webrtc-adapter and getStats call.

*Description of changes:*
Updated webrtc-adapter. Updated getStats call to retrieve a legacy stats report from browsers that support it, otherwise it retrieves a standardized stats report.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
