### PR TITLE
make accept request become async

### DIFF
--- a/src/js/signaling.js
+++ b/src/js/signaling.js
@@ -189,6 +189,16 @@ export class PendingAcceptState extends SignalingState {
         }
     }
     accept() {
+        this.sendAcceptRequest();
+        this.transit(new TalkingState(this._signaling));
+    }
+    channelDown() {
+        this.transit(new FailedState(this._signaling));
+    }
+    get name() {
+        return "PendingAcceptState";
+    }
+    async sendAcceptRequest() {
         var acceptId = uuid();
         this._signaling._wss.send(JSON.stringify({
             jsonrpc: '2.0',
@@ -196,13 +206,6 @@ export class PendingAcceptState extends SignalingState {
             params: {},
             id: acceptId
         }));
-        this.transit(new PendingAcceptAckState(this._signaling, acceptId));
-    }
-    channelDown() {
-        this.transit(new FailedState(this._signaling));
-    }
-    get name() {
-        return "PendingAcceptState";
     }
 }
 export class PendingAcceptAckState extends FailOnTimeoutState {

--- a/test/unit/signaling.js
+++ b/test/unit/signaling.js
@@ -283,7 +283,7 @@ describe('signalingTest', () => {
             chai.assert.isNotNull(acceptReq.params);
             chai.assert.isNotNull(acceptReq.id);
             chai.assert(signaling.transit.calledOnce);
-            chai.assert(signaling.transit.args[0][0] instanceof PendingAcceptAckState);
+            chai.assert(signaling.transit.args[0][0] instanceof TalkingState);
         });
     });
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

make accept request become async so that it only work as answer ack and won't fail call if browser is not able to send it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
