### PR TITLE
Plan-b deprecation

### DIFF
--- a/src/js/rtc_const.js
+++ b/src/js/rtc_const.js
@@ -33,9 +33,8 @@ export const BYE_METHOD_NAME = "bye";
 
 export const RTC_PEER_CONNECTION_CONFIG = {
     iceTransportPolicy: 'relay',
-    rtcpMuxPolicy: 'require',
     bundlePolicy: 'balanced',
-    sdpSemantics: 'plan-b'
+    rtcpMuxPolicy: 'require'
 };
 
 export const RTC_PEER_CONNECTION_OPTIONAL_CONFIG = {

--- a/src/js/rtc_const.js
+++ b/src/js/rtc_const.js
@@ -33,8 +33,8 @@ export const BYE_METHOD_NAME = "bye";
 
 export const RTC_PEER_CONNECTION_CONFIG = {
     iceTransportPolicy: 'relay',
-    bundlePolicy: 'balanced',
     rtcpMuxPolicy: 'require'
+    bundlePolicy: 'balanced'
 };
 
 export const RTC_PEER_CONNECTION_OPTIONAL_CONFIG = {


### PR DESCRIPTION
Removed Plan-B from connect-rtc.js

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
