### PR TITLE
fix: statsReport Conditional

### DIFF
--- a/src/js/rtp-stats.js
+++ b/src/js/rtp-stats.js
@@ -15,7 +15,7 @@ export function extractMediaStatsFromStats(timestamp, stats, streamType) {
             if (statsReport.type === 'ssrc') {
                 reportType = statsReport.type;
                 // Legacy report. Legacy report names stats with google specific names.
-                if (parseInt(statsReport.stat('packetsSent')) && statsReport.stat('mediaType') == 'audio' && streamType === 'audio_output') {
+                if (parseInt(statsReport.stat('packetsSent')) >= 0 && statsReport.stat('mediaType') == 'audio' && streamType === 'audio_output') {
                     extractedStats = {
                         timestamp:          timestamp,
                         packetsCount:       parseInt(statsReport.stat('packetsSent')),
@@ -27,7 +27,7 @@ export function extractMediaStatsFromStats(timestamp, stats, streamType) {
                         jbMilliseconds:     when_defined(parseInt(statsReport.stat('googJitterReceived')))
                     };
 
-                } else if (parseInt(statsReport.stat('packetsReceived')) && statsReport.stat('mediaType') == 'audio' && streamType === 'audio_input') {
+                } else if (parseInt(statsReport.stat('packetsReceived')) >= 0 && statsReport.stat('mediaType') == 'audio' && streamType === 'audio_input') {
                     extractedStats = {
                         timestamp:          timestamp,
                         packetsCount:       parseInt(statsReport.stat('packetsReceived')),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

parseInt returns an integer or `NaN`.
`NaN` is `false` when evaluated.
On the other hand, `0` will also be `false` when evaluated.
If it evaluates to `0`, it must evaluate to `true`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
