### PR TITLE
Remove webrtc-adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     "version": "",
     "postversion": "export GITTAG=\"echo $(git describe --abbrev=0 --tags | sed 's/^v//')\" && git push --force --set-upstream origin bumpVersion --follow-tags && git checkout gh-pages && git pull && cp out/connect-rtc-debug.js ./connect-rtc-debug-`$GITTAG`.js && cp out/connect-rtc.min.js ./connect-rtc-`$GITTAG`.min.js && ln -fs connect-rtc-debug-`$GITTAG`.js connect-rtc-debug-latest.js && ln -fs connect-rtc-`$GITTAG`.min.js connect-rtc-latest.min.js && git add connect-rtc*.js && git commit -m `$GITTAG` && git push --set-upstream origin gh-pages && git checkout master",
     "prepublish": "grunt build",
-    "test": "grunt && mocha --compilers js:babel-core/register test/unit"
+    "test": "grunt && mocha --compilers js:babel-core/register test/unit",
+    "build": "grunt"
   },
   "dependencies": {
-    "uuid": "^3.0.1",
-    "webrtc-adapter": "^6.4.0"
+    "sdp": "^3.0.3",
+    "uuid": "^3.0.1"
   },
   "engines": {
     "npm": ">=3.10.0",

--- a/src/js/connect-rtc.js
+++ b/src/js/connect-rtc.js
@@ -1,34 +1,5 @@
 /**
  * @license
- * Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-/**
- * @license
- * License info for webrtc-adapter module assembled into js bundle:
- *
- * Copyright (c) 2014, The WebRTC project authors. All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
- *
- * Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
- *
- * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
- *
- * Neither the name of Google nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
-/**
- * @license
- * License info for sdp module assembled into js bundle:
- *
- * See https://www.npmjs.com/package/sdp
- */
-import 'webrtc-adapter';
-/**
- * @license
  * License info for uuid module assembled into js bundle:
  *
  * The MIT License (MIT)


### PR DESCRIPTION
**Amazon alias**:
@tylgross

**Description of changes:**
Removing `webrtc-adapter` decreases the size of `connect-rtc-js` from `193kb` to `121kb`, about 37%. `webrtc-adapter` patches prefixed versions of the WebRTC library and adds some other functionality, despite the fact that WebRTC is well-supported in all modern browsers and the API is stable. I couldn't find any evidence that connect is using experimental or semi-experimental portions of WebRTC APIs.

In addition to this, [Amazon Connect only supports the the last three major versions of Chrome, Firefox, and Firefox ESR](https://docs.aws.amazon.com/connect/latest/adminguide/browsers.html). For these reasons, it makes sense to me to remove this dependency. Given that Connect has deprecated support for older browsers, I don't see this as a breaking change, but I don't think I'd argue if someone else thought it was.

If this change is considered too risky, an alternative might be to update to version 8 of `webrtc-adapter`, which still saves about 20kb.

**Web RTC Support**
<img width="1486" alt="Screen Shot 2022-02-09 at 1 45 18 PM" src="https://user-images.githubusercontent.com/29755902/153269458-8a7f8f2a-0f67-4544-9eda-6fdaf2199db8.png">

**Side note:**
The support matrix here is partially incorrect in that Samsung Internet (being a fork of Chrome) fully supports unprefixed WebRTC.

**From Device:**
![Samsung Internet](https://user-images.githubusercontent.com/29755902/153269757-fb47e18f-a95d-4310-9e69-fcf516e64ebf.jpg)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.