### PR TITLE
Refresh stale peer conection based on ICE connection state

### DIFF
--- a/src/js/rtc_session.js
+++ b/src/js/rtc_session.js
@@ -871,7 +871,7 @@ export default class RtcSession {
         var now = new Date();
         self._sessionReport.sessionStartTime = now;
         self._connectTimeStamp = now.getTime();
-        if (pc && pc.signalingState != 'closed') {
+        if (pc && pc.iceConnectionState != 'closed' && pc.iceConnectionState != 'failed' && pc.iceConnectionState != 'disconnected') {
             self._pc = pc;
         } else {
             if (pc) {


### PR DESCRIPTION
*Description of changes:*
With persistent connection feature, RTC sessions can become stale if the CCP enters sleep/hibernate mode. This change will check the health of the ICE connection before connecting and recreate the peer connection if the ICE connection is not in a healthy state. If the ICE connection state is closed, failed, or disconnected then the peer connection may be stale or unusable and should be recreated. See https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/iceConnectionState for documentation on ice connection state

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
