### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -3,7 +3,7 @@ $(document).ready(function () {
     var videoElement = $('#remoteVideo')[0];
 
     if (window.location.hash) {
-        $('#softphoneMediaInfo').val(decodeURIComponent(window.location.hash.substr(1)));
+        $('#softphoneMediaInfo').val(decodeURIComponent(window.location.hash.slice(1)));
     }
 
     $('#makeCall').click(function () {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
