### PR TITLE
adding grunt-replace to release tasks

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -94,9 +94,9 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-contrib-connect');
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-replace');
-    grunt.registerTask('default', ['eslint', 'browserify','replace', 'uglify']);
+    grunt.registerTask('default', ['eslint', 'browserify', 'replace', 'uglify']);
     grunt.registerTask('lint', ['eslint']);
-    grunt.registerTask('build', ['browserify', 'uglify']);
+    grunt.registerTask('build', ['browserify', 'replace', 'uglify']);
     grunt.registerTask('copyForPublish', ['copy']);
     grunt.registerTask('demo', ['build', 'connect', 'watch']);
 };


### PR DESCRIPTION
*Issue #, if available:*
Previously we added grunt-replace to "grunt default" only, which is for local development. This commit add grunt-replace tasks to grunt build, which is for release 
*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
