### PR TITLE
doing replace task after rtcJsVersion is increased

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-rtc-js",
-  "version": "1.1.16",
+  "version": "1.1.17",
   "description": "Amazon Connect softphone library",
   "license": "Apache-2.0",
   "main": "./src/js/connect-rtc.js",
@@ -20,7 +20,7 @@
   ],
   "scripts": {
     "preversion": "git stash && git checkout master && git pull && npm test && git checkout -B bumpVersion",
-    "version": "grunt build && grunt copyForPublish && git add package.json release/* && git commit -m 'Add connect-rtc-js artifacts' --allow-empty",
+    "version": "grunt build && grunt copyForPublish && git add package.json release/* ",
     "postversion": "export GITTAG=\"echo $(git describe --abbrev=0 --tags | sed 's/^v//')\" && git push --force --set-upstream origin bumpVersion --follow-tags && git checkout gh-pages && git pull && cp out/connect-rtc-debug.js ./connect-rtc-debug-`$GITTAG`.js && cp out/connect-rtc.min.js ./connect-rtc-`$GITTAG`.min.js && ln -fs connect-rtc-debug-`$GITTAG`.js connect-rtc-debug-latest.js && ln -fs connect-rtc-`$GITTAG`.min.js connect-rtc-latest.min.js && git add connect-rtc*.js && git commit -m `$GITTAG` && git push --set-upstream origin gh-pages && git checkout master",
     "prepublish": "grunt build",
     "test": "grunt && mocha --compilers js:babel-core/register test/unit"
@@ -43,7 +43,7 @@
     "eslint-config-webrtc": "^1.0.0",
     "faucet": "0.0.1",
     "geckodriver": "^1.12.1",
-    "grunt": "^1.4.1",
+    "grunt": "^1.5.3",
     "grunt-browserify": "^5.3.0",
     "grunt-cli": "^1.0.0",
     "grunt-contrib-clean": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "Anil Kumar Vuta <anilvuta@amazon.com>"
   ],
   "scripts": {
-    "preversion": "git stash && git checkout master && git pull && npm test && git checkout -B bumpVersion && grunt build && grunt copyForPublish && git add package.json release/* && git commit -m 'Add connect-rtc-js artifacts' --allow-empty",
-    "version": "",
+    "preversion": "git stash && git checkout master && git pull && npm test && git checkout -B bumpVersion",
+    "version": "grunt build && grunt copyForPublish && git add package.json release/* && git commit -m 'Add connect-rtc-js artifacts' --allow-empty",
     "postversion": "export GITTAG=\"echo $(git describe --abbrev=0 --tags | sed 's/^v//')\" && git push --force --set-upstream origin bumpVersion --follow-tags && git checkout gh-pages && git pull && cp out/connect-rtc-debug.js ./connect-rtc-debug-`$GITTAG`.js && cp out/connect-rtc.min.js ./connect-rtc-`$GITTAG`.min.js && ln -fs connect-rtc-debug-`$GITTAG`.js connect-rtc-debug-latest.js && ln -fs connect-rtc-`$GITTAG`.min.js connect-rtc-latest.min.js && git add connect-rtc*.js && git commit -m `$GITTAG` && git push --set-upstream origin gh-pages && git checkout master",
     "prepublish": "grunt build",
     "test": "grunt && mocha --compilers js:babel-core/register test/unit"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-rtc-js",
-  "version": "1.1.17",
+  "version": "1.1.16",
   "description": "Amazon Connect softphone library",
   "license": "Apache-2.0",
   "main": "./src/js/connect-rtc.js",
@@ -43,7 +43,7 @@
     "eslint-config-webrtc": "^1.0.0",
     "faucet": "0.0.1",
     "geckodriver": "^1.12.1",
-    "grunt": "^1.5.3",
+    "grunt": "^1.4.1",
     "grunt-browserify": "^5.3.0",
     "grunt-cli": "^1.0.0",
     "grunt-contrib-clean": "^1.0.0",


### PR DESCRIPTION
**How it used to work?**
We used to create release file during `preVersion`, and do a commit.
Then during `version`, npm will update the package.json with the new version number and do a second commit automatically due to the default commit-hooks setting of npm is true.
If you check previous commits, we always has 2 commits for 1 release.

**Why we need to change it?**
1. the release file generated during preVersion will have the old version ID. So we need to move it from `preVersion` to `version`.
2. Once we move those tasks to version, we need to remove the commit at the end, because npm version will do a commit automatically, and that commit does not allow empty by default. If we do not remove it, npm version will fail due to empty commits

**What is changed?**
 1. moved the release file generation logic to Version
 2. removed additional commit 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
