### PR TITLE
Bug fix for early media peer connection

### DIFF
--- a/src/js/rtc_peer_connection_factory.js
+++ b/src/js/rtc_peer_connection_factory.js
@@ -35,7 +35,7 @@ export default class RtcPeerConnectionFactory {
     }
 
     _isEarlyMediaConnectionSupported() {
-        this._strategy._isEarlyMediaConnectionSupported();
+        return this._strategy._isEarlyMediaConnectionSupported();
     }
 
     //This will handle the idleConnection and quota limits notification from the server


### PR DESCRIPTION
*Issue #, if available:*
_isEarlyMediaConnectionSupported returns undefined since we are missing the return value.

*Description of changes:*
Add return value for _isEarlyMediaConnectionSupported

Tested in local CCP, early media connection was enabled on supported browser.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
